### PR TITLE
Python 3 migration bugfix in previously uncovered code branch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,9 @@ CHANGES
 
 - Claim support for Python 3.4 and 3.5.
 
+- Fix a bug occurring in Python 3 when the principal could not be adapted to
+  `ILoggingInfo`.
+
 4.0.0a4 (2013-03-19)
 --------------------
 

--- a/src/zope/app/wsgi/__init__.py
+++ b/src/zope/app/wsgi/__init__.py
@@ -67,7 +67,7 @@ class WSGIPublisherApplication(object):
         # Get logging info from principal for log use
         logging_info = ILoggingInfo(request.principal, None)
         if logging_info is None:
-            message = '-'
+            message = b'-'
         else:
             message = logging_info.getLogMessage()
 

--- a/src/zope/app/wsgi/tests.py
+++ b/src/zope/app/wsgi/tests.py
@@ -12,16 +12,17 @@
 #
 ##############################################################################
 """WSGI tests"""
+import doctest
+import io
+import re
+import unittest
+
 from zope.app.wsgi.testing import SillyMiddleWare
 from zope.app.wsgi.testlayer import BrowserLayer
 from zope.authentication.interfaces import IUnauthenticatedPrincipal
 from zope.component.testlayer import ZCMLFileLayer
 from zope.publisher.interfaces.logginginfo import ILoggingInfo
 from zope.testing import renormalizing
-import doctest
-import io
-import re
-import unittest
 import zope.app.wsgi
 import zope.component
 import zope.component.testing

--- a/src/zope/app/wsgi/tests.py
+++ b/src/zope/app/wsgi/tests.py
@@ -12,21 +12,22 @@
 #
 ##############################################################################
 """WSGI tests"""
+from zope.app.wsgi.testing import SillyMiddleWare
+from zope.app.wsgi.testlayer import BrowserLayer
 from zope.authentication.interfaces import IUnauthenticatedPrincipal
+from zope.component.testlayer import ZCMLFileLayer
 from zope.publisher.interfaces.logginginfo import ILoggingInfo
+from zope.testing import renormalizing
 import doctest
 import io
 import re
 import unittest
 import zope.app.wsgi
-import zope.event
 import zope.component
 import zope.component.testing
-from zope.app.wsgi.testing import SillyMiddleWare
-from zope.app.wsgi.testlayer import BrowserLayer
-from zope.component.testlayer import ZCMLFileLayer
-from zope.testing import renormalizing
+import zope.event
 import zope.interface
+
 
 def creating_app_w_paste_emits_ProcessStarting_event():
     """
@@ -64,6 +65,7 @@ def creating_app_w_paste_emits_ProcessStarting_event():
 
     >>> zope.event.subscribers.remove(subscriber)
     """
+
 
 wsgiapp_layer = BrowserLayer(zope.app.wsgi, name='wsgiapp', allowTearDown=True)
 def setUpWSGIApp(test):

--- a/src/zope/app/wsgi/tests.py
+++ b/src/zope/app/wsgi/tests.py
@@ -69,8 +69,11 @@ def creating_app_w_paste_emits_ProcessStarting_event():
 
 
 wsgiapp_layer = BrowserLayer(zope.app.wsgi, name='wsgiapp', allowTearDown=True)
+
+
 def setUpWSGIApp(test):
     test.globs['wsgi_app'] = wsgiapp_layer.make_wsgi_app()
+
 
 def setUpSillyWSGIApp(test):
     test.globs['wsgi_app'] = wsgiapp_layer.make_wsgi_app(SillyMiddleWare)
@@ -111,13 +114,12 @@ class WSGIPublisherApplicationTests(unittest.TestCase):
 
 
 def test_suite():
-
     suites = []
     checker = renormalizing.RENormalizing([
         (re.compile(
             r"&lt;class 'zope.component.interfaces.ComponentLookupError'&gt;"),
          r'ComponentLookupError'),
-        ])
+    ])
 
     filereturns_suite = doctest.DocFileSuite(
         'filereturns.txt', setUp=setUpWSGIApp)
@@ -131,18 +133,18 @@ def test_suite():
     suites.append(unittest.makeSuite(WSGIPublisherApplicationTests))
 
     readme_test = doctest.DocFileSuite(
-            'README.txt',
-            checker=checker,
-            optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS)
+        'README.txt',
+        checker=checker,
+        optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS)
     # This test needs its own layer/teardown, since it registers components
     # with objects that later do not exist.
     readme_test.layer = ZCMLFileLayer(zope.app.wsgi, name="README")
     suites.append(readme_test)
 
     doctest_suite = doctest.DocFileSuite(
-            'fileresult.txt', 'paste.txt',
-            checker=checker,
-            optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS)
+        'fileresult.txt', 'paste.txt',
+        checker=checker,
+        optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS)
     doctest_suite.layer = ZCMLFileLayer(zope.app.wsgi)
     suites.append(doctest_suite)
 


### PR DESCRIPTION
Fix a bug occurring in Python 3 when the principal could not be adapted to `ILoggingInfo`.

The message has to be `bytes` because it gets decoded to `str` later on.