### PR TITLE
Avoid deprecation warning with `base64.b64encode`.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 4.1.0 (unreleased)
 ------------------
 
-- BUGFIX: Use `base64.b64encode` to avoid deprecation warning with Python 3.
+- Use `base64.b64encode` to avoid deprecation warning with Python 3.
 
 
 4.0.0 (2016-08-08)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 4.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BUGFIX: Use `base64.b64encode` to avoid deprecation warning with Python 3.
 
 
 4.0.0 (2016-08-08)

--- a/src/zope/app/wsgi/testlayer.py
+++ b/src/zope/app/wsgi/testlayer.py
@@ -37,7 +37,7 @@ def auth_header(header):
         if p is None:
             p = ''
         plain = '%s:%s' % (u, p)
-        auth = base64.encodestring(plain.encode('utf-8'))
+        auth = base64.b64encode(plain.encode('utf-8'))
         return 'Basic %s' % str(auth.rstrip().decode('latin1'))
     return header
 

--- a/src/zope/app/wsgi/tests.py
+++ b/src/zope/app/wsgi/tests.py
@@ -113,6 +113,35 @@ class WSGIPublisherApplicationTests(unittest.TestCase):
         self.assertEqual('-', environ['wsgi.logging_info'])
 
 
+class AuthHeaderTestCase(unittest.TestCase):
+
+    def test_auth_encoded(self):
+        from zope.app.wsgi.testlayer import auth_header
+        header = 'Basic Z2xvYmFsbWdyOmdsb2JhbG1ncnB3'
+        self.assertEquals(auth_header(header), header)
+
+    def test_auth_non_encoded(self):
+        from zope.app.wsgi.testlayer import auth_header
+        header = 'Basic globalmgr:globalmgrpw'
+        expected = 'Basic Z2xvYmFsbWdyOmdsb2JhbG1ncnB3'
+        self.assertEquals(auth_header(header), expected)
+
+    def test_auth_non_encoded_empty(self):
+        from zope.app.wsgi.testlayer import auth_header
+        header = 'Basic globalmgr:'
+        expected = 'Basic Z2xvYmFsbWdyOg=='
+        self.assertEquals(auth_header(header), expected)
+        header = 'Basic :pass'
+        expected = 'Basic OnBhc3M='
+        self.assertEquals(auth_header(header), expected)
+
+    def test_auth_non_encoded_colon(self):
+        from zope.app.wsgi.testlayer import auth_header
+        header = 'Basic globalmgr:pass:pass'
+        expected = 'Basic Z2xvYmFsbWdyOnBhc3M6cGFzcw=='
+        self.assertEquals(auth_header(header), expected)
+
+
 def test_suite():
     suites = []
     checker = renormalizing.RENormalizing([
@@ -131,6 +160,7 @@ def test_suite():
     suites.append(dt_suite)
 
     suites.append(unittest.makeSuite(WSGIPublisherApplicationTests))
+    suites.append(unittest.makeSuite(AuthHeaderTestCase))
 
     readme_test = doctest.DocFileSuite(
         'README.txt',


### PR DESCRIPTION
Projects which depend on the `zope.app.wsgi.testlayer` will have a
`DeprecationWarning` issued when used with Python 3. This is in particular
troublesome when it happens in doctests. We have this method in a variety of
places in the packages of Zopefoundation, which makes it harder to update them
all at once.

Also copied tests over from `zope.app.testing` to increase coverage.