### PR TITLE
Add support for PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@
 language: python
 python:
     - 2.7
+    - pypy-5.4.1
     - 3.3
     - 3.4
     - 3.5
 install:
-    - pip install tox-travis
+    - pip install -U pip
+    - pip install -U -e .[test]
 script:
-    - tox
+    - zope-testrunner --test-path=src
 notifications:
     email: false
+cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,13 @@ python:
     - 3.4
     - 3.5
 install:
-    - pip install -U pip
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
     - pip install -U -e .[test]
 script:
-    - zope-testrunner --test-path=src
+    - coverage run `which zope-testrunner` --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
 cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ CHANGES
 
 - Use `base64.b64encode` to avoid deprecation warning with Python 3.
 
+- Add support for PyPy.
+
 
 4.0.0 (2016-08-08)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 ##############################################################################
 """Setup for zope.app.wsgi package
 """
+import os
 from setuptools import setup, find_packages
 
 TESTS_REQUIRE = [
@@ -33,15 +34,20 @@ TESTS_REQUIRE = [
     'zope.testrunner',
 ]
 
+def read(*rnames):
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
+
+
 setup(
     name='zope.app.wsgi',
     version='4.1.0.dev0',
     url='http://pypi.python.org/pypi/zope.app.wsgi',
     license='ZPL 2.1',
     description='WSGI application for the zope.publisher',
-    long_description=open('README.rst').read() +
+    long_description=read('README.rst') +
         '\n\n' +
-        open('CHANGES.rst').read(),
+        read('CHANGES.rst'),
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     classifiers=[

--- a/src/zope/app/wsgi/README.txt
+++ b/src/zope/app/wsgi/README.txt
@@ -143,7 +143,7 @@ example:
   >>> import os, tempfile
   >>> temp_dir = tempfile.mkdtemp()
   >>> sitezcml = os.path.join(temp_dir, 'site.zcml')
-  >>> written = open(sitezcml, 'w').write('<configure />')
+  >>> with open(sitezcml, 'w') as f: _ = f.write('<configure />')
 
   >>> configFile = io.StringIO(u'''
   ... site-definition %s
@@ -204,4 +204,3 @@ portability.
 
 For more information, refer to the WSGI specification:
 http://www.python.org/peps/pep-0333.html
-

--- a/src/zope/app/wsgi/README.txt
+++ b/src/zope/app/wsgi/README.txt
@@ -143,7 +143,8 @@ example:
   >>> import os, tempfile
   >>> temp_dir = tempfile.mkdtemp()
   >>> sitezcml = os.path.join(temp_dir, 'site.zcml')
-  >>> with open(sitezcml, 'w') as f: _ = f.write('<configure />')
+  >>> with open(sitezcml, 'w') as f:
+  ...     _ = f.write('<configure />')
 
   >>> configFile = io.StringIO(u'''
   ... site-definition %s

--- a/src/zope/app/wsgi/paste.txt
+++ b/src/zope/app/wsgi/paste.txt
@@ -34,9 +34,9 @@ Let's create testing site.zcml and zope.conf file.
   >>> import os, tempfile
   >>> temp_dir = tempfile.mkdtemp()
   >>> sitezcml = os.path.join(temp_dir, 'site.zcml')
-  >>> written = open(sitezcml, 'w').write('<configure />')
+  >>> with open(sitezcml, 'w') as f: _ = f.write('<configure />')
   >>> zopeconf = os.path.join(temp_dir, 'zope.conf')
-  >>> written = open(zopeconf, 'w').write('''
+  >>> with open(zopeconf, 'w') as f: _ = f.write('''
   ... site-definition %s
   ...
   ... <zodb>

--- a/src/zope/app/wsgi/paste.txt
+++ b/src/zope/app/wsgi/paste.txt
@@ -34,9 +34,11 @@ Let's create testing site.zcml and zope.conf file.
   >>> import os, tempfile
   >>> temp_dir = tempfile.mkdtemp()
   >>> sitezcml = os.path.join(temp_dir, 'site.zcml')
-  >>> with open(sitezcml, 'w') as f: _ = f.write('<configure />')
+  >>> with open(sitezcml, 'w') as f:
+  ...     _ = f.write('<configure />')
   >>> zopeconf = os.path.join(temp_dir, 'zope.conf')
-  >>> with open(zopeconf, 'w') as f: _ = f.write('''
+  >>> with open(zopeconf, 'w') as f:
+  ...     _ = f.write('''
   ... site-definition %s
   ...
   ... <zodb>

--- a/src/zope/app/wsgi/tests.py
+++ b/src/zope/app/wsgi/tests.py
@@ -40,9 +40,11 @@ def creating_app_w_paste_emits_ProcessStarting_event():
     >>> import os, tempfile
     >>> temp_dir = tempfile.mkdtemp()
     >>> sitezcml = os.path.join(temp_dir, 'site.zcml')
-    >>> with open(sitezcml, 'w') as f: _ = f.write('<configure />')
+    >>> with open(sitezcml, 'w') as f:
+    ...     _ = f.write('<configure />')
     >>> zopeconf = os.path.join(temp_dir, 'zope.conf')
-    >>> with open(zopeconf, 'w') as f: _ = f.write('''
+    >>> with open(zopeconf, 'w') as f:
+    ...     _ = f.write('''
     ... site-definition %s
     ...
     ... <zodb>

--- a/src/zope/app/wsgi/tests.py
+++ b/src/zope/app/wsgi/tests.py
@@ -40,9 +40,9 @@ def creating_app_w_paste_emits_ProcessStarting_event():
     >>> import os, tempfile
     >>> temp_dir = tempfile.mkdtemp()
     >>> sitezcml = os.path.join(temp_dir, 'site.zcml')
-    >>> written = open(sitezcml, 'w').write('<configure />')
+    >>> with open(sitezcml, 'w') as f: _ = f.write('<configure />')
     >>> zopeconf = os.path.join(temp_dir, 'zope.conf')
-    >>> wrotten = open(zopeconf, 'w').write('''
+    >>> with open(zopeconf, 'w') as f: _ = f.write('''
     ... site-definition %s
     ...
     ... <zodb>

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = coverage-clean,py27,py33,py34,py35,coverage-report
+envlist = coverage-clean,py27,pypy,py33,py34,py35,coverage-report
 
 [testenv]
 commands =
-    coverage run setup.py ftest -q
+    coverage run {envbindir}/zope-testrunner --test-path=src
 setenv =
   COVERAGE_FILE=.coverage.{envname}
 deps =


### PR DESCRIPTION
Fixes #5

Also directly use zope-testrunner instead of redirecting through tox.ini
on travis. This lets us use travis caching for much faster test runs.

Also enable coverage reporting.