### PR TITLE
Don't assume headers are unicode in FakeResponse.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ develop-eggs
 dist
 parts
 htmlcov/
+.coverage.py*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 # manual (marker for update script)
 language: python
+sudo: false
 python:
     - 2.7
     - pypy-5.4.1
     - 3.3
     - 3.4
     - 3.5
+    - 3.6
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls
     - pip install -U -e .[test]
 script:
-    - coverage run `which zope-testrunner` --test-path=src
+    - coverage run -m zope.testrunner --test-path=src --all
 after_success:
     - coveralls
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,18 @@ CHANGES
 4.1.0 (unreleased)
 ------------------
 
-- Use `base64.b64encode` to avoid deprecation warning with Python 3.
+- Use ``base64.b64encode`` to avoid deprecation warning with Python 3.
 
 - Add support for PyPy.
 
+- Add support for Python 3.6.
+
+- Fix the testlayer's ``FakeResponse`` assuming that headers were in
+  unicode on Python 2, where they should usually be encoded bytes
+  already. This could lead to UnicodeDecodeError if the headers
+  contained non-ascii characters. Also make it implement
+  ``__unicode__`` on Python 2 and ``__bytes__`` on Python 3 to ease
+  cross version testing. See `issue 7 <https://github.com/zopefoundation/zope.app.wsgi/issues/7>`_.
 
 4.0.0 (2016-08-08)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation',
         'Programming Language :: Python :: Implementation :: CPython',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = coverage-clean,py27,pypy,py33,py34,py35,coverage-report
+envlist = coverage-clean,py27,pypy,py33,py34,py35,py36,coverage-report
 
 [testenv]
 commands =
-    coverage run {envbindir}/zope-testrunner --test-path=src
+    coverage run -m zope.testrunner --test-path=src --all []
 setenv =
   COVERAGE_FILE=.coverage.{envname}
 deps =


### PR DESCRIPTION
Fix the testlayer's ``FakeResponse`` assuming that headers were in unicode on Python 2, where they should usually be encoded bytes already. This could lead to UnicodeDecodeError if the headers
contained non-ascii characters. Also make it implement ``__unicode__`` on Python 2 and ``__bytes__`` on Python 3 to ease cross version testing.

I can confirm this fixes the issue seen in the doctests of zope.app.form.

Also add explicit Py3.6 support.

Fixes #7.