### PR TITLE
RFC: Improve HTTPCaller compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ CHANGES
 
 - Drop support for Python 3.3 and 3.4.
 
+- Fix the testlayer's ``http()`` to accept leading whitespace in HTTP requests,
+  for compatibility with zope.app.testing.functional's HTTPCaller.
+
+- Add a ``server_protocol`` attribute to ``FakeResponse`` so you can customize
+  the output to be more compatible with zope.app.testing.functional's
+  HTTPCaller.
 
 4.1.0 (2017-04-27)
 ------------------

--- a/src/zope/app/wsgi/testlayer.py
+++ b/src/zope/app/wsgi/testlayer.py
@@ -152,6 +152,9 @@ class FakeResponse(object):
 
     """
 
+    # XXX: zope.app.testing.functional used to respond with HTTP/1.1
+    server_protocol = b'HTTP/1.0'
+
     def __init__(self, response):
         self.response = response
 
@@ -173,7 +176,7 @@ class FakeResponse(object):
     def getOutput(self):
         status = self.response.status
         status = status.encode('latin1') if not isinstance(status, bytes) else status
-        parts = [b'HTTP/1.0 ' + status]
+        parts = [self.server_protocol + b' ' + status]
 
         headers = [(k.encode('latin1') if not isinstance(k, bytes) else k,
                     v.encode('latin1') if not isinstance(v, bytes) else v)
@@ -241,6 +244,7 @@ class XMLRPCTestTransport(xmlrpcclient.Transport):
                 dict(extra_headers)["Authorization"],)
 
         request += "\n" + request_body
+        # XXX: http() needs to be passed a wsgi app!  where do we get a wsgi app?
         response = http(request, handle_errors=self.handleErrors)
 
         errcode = response.getStatus()

--- a/src/zope/app/wsgi/testlayer.py
+++ b/src/zope/app/wsgi/testlayer.py
@@ -208,7 +208,7 @@ class FakeResponse(object):
 
 
 def http(wsgi_app, string, handle_errors=True):
-    request = TestRequest.from_file(BytesIO(string))
+    request = TestRequest.from_file(BytesIO(string.lstrip()))
     request.environ['wsgi.handleErrors'] = handle_errors
     response = request.get_response(wsgi_app)
     return FakeResponse(response)


### PR DESCRIPTION
zope.app.testing.functional.http() used to respond with "HTTP/1.1 ...",
zope.app.wsgi.testlayer.http() hardcodes the server protocol as
"HTTP/1.0 ...".

This is annoying when I'm trying to port old large test suites.  Let's
at least make this easier to customize by subclassing and overriding a
single attribute, without having to rewrite the entire method.

zope.app.testing.functional.http() also used to accept leading newlines
in HTTP requests, e.g.
    
        >>> print http(r"""
        ... GET / HTTP/1.1
        ... Headers: headers etc.
        ... """)
