### PR TITLE
Make http pass through request protocol

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@
 CHANGES
 =======
 
-4.2.1 (unreleased)
+4.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix the testlayer's ``http()`` to pass through the request protocol as the
+  response protocol, for compatibility with zope.app.testing.functional's
+  HTTPCaller.
 
 
 4.2.0 (2020-03-23)

--- a/src/zope/app/wsgi/testlayer.txt
+++ b/src/zope/app/wsgi/testlayer.txt
@@ -50,9 +50,16 @@ One can set error handling behavior::
     ZeroDivisionError: integer division or modulo by zero
 
 The http caller is more low level than the Browser.
-It exposes the same error handling parameter:
 
     >>> from zope.app.wsgi.testlayer import http
+    >>> response = http(wsgi_app, b'GET /index.html HTTP/1.0')
+    >>> print(response)  #doctest: +ELLIPSIS
+    HTTP/1.0 200 Ok
+    Content-Type: text/html...
+    ...Hello from the silly middleware...
+
+It exposes the same error handling parameter:
+
     >>> response = http(wsgi_app, b'GET /error.html HTTP/1.1')
     >>> response.getStatus() == 500
     True
@@ -61,6 +68,14 @@ It exposes the same error handling parameter:
     Traceback (most recent call last):
     ...
     ZeroDivisionError: integer division or modulo by zero
+
+It passes through the request protocol as the response protocol:
+
+    >>> response = http(wsgi_app, b'GET /index.html HTTP/1.1')
+    >>> print(response)  #doctest: +ELLIPSIS
+    HTTP/1.1 200 Ok
+    Content-Type: text/html...
+    ...Hello from the silly middleware...
 
 Clean up:
 


### PR DESCRIPTION
zope.app.testing.functional's HTTPCaller passed through the request
protocol as the response protocol, so do the same here to ease porting.

This may entail some test changes in other packages that assume that the
response protocol is always HTTP/1.0.