### PR TITLE
Improve support for `multipart >= 1`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Drop support for Python 3.7.
 
+- Improve support for ``multipart >= 1``.
+
 
 5.0 (2023-01-19)
 ================

--- a/src/zope/app/wsgi/testlayer.py
+++ b/src/zope/app/wsgi/testlayer.py
@@ -200,8 +200,12 @@ class FakeResponse:
         return bytes(self).decode('latin-1')
 
 
-def http(wsgi_app, string, handle_errors=True):
-    request = TestRequest.from_file(BytesIO(string.lstrip()))
+def http(wsgi_app, query_str, handle_errors=True):
+    if not isinstance(query_str, bytes):
+        query_str = query_str.encode("ascii")
+    # `multipart >= 1` insists on `\r\n` line endings:
+    query_str = b"\r\n".join(query_str.splitlines())
+    request = TestRequest.from_file(BytesIO(query_str.lstrip()))
     request.environ['wsgi.handleErrors'] = handle_errors
     response = request.get_response(wsgi_app)
     return FakeResponse(response, request=request)

--- a/src/zope/app/wsgi/testlayer.txt
+++ b/src/zope/app/wsgi/testlayer.txt
@@ -77,6 +77,15 @@ It passes through the request protocol as the response protocol:
     Content-Type: text/html...
     ...Hello from the silly middleware...
 
+It allows to use `str` instead of `bytes` as query string:
+
+    >>> response = http(wsgi_app, 'GET /index.html HTTP/1.1')
+    >>> print(response)  #doctest: +ELLIPSIS
+    HTTP/1.1 200 Ok
+    Content-Type: text/html...
+    ...Hello from the silly middleware...
+
+
 Clean up:
 
     >>> import zope.publisher.interfaces.browser


### PR DESCRIPTION
I moved https://github.com/zopefoundation/zope.app.form/pull/15 here, so we will get the fix for free in other packages using `zope.app.wsgi`.