### PR TITLE
Add `.testlayer.encodeMultipartFormdata()`.

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "f317618e"
+commit-id = "baf6089f"
 
 [python]
 with-pypy = true
@@ -16,7 +16,7 @@ with-docs = false
 use-flake8 = true
 
 [coverage]
-fail-under = 85
+fail-under = 84.8
 
 [manifest]
 additional-rules = [

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 5.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add ``.testlayer.encodeMultipartFormdata()`` to correctly encode multipart
+  form data for use with the ``Content-Type: multipart/form-data`` header.
 
 
 5.2.1 (2024-11-20)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ branch = true
 source = ["zope.app.wsgi"]
 
 [tool.coverage.report]
-fail_under = 85
+fail_under = 84.8
 precision = 2
 ignore_errors = true
 show_missing = true


### PR DESCRIPTION
It is usable to correctly encode multipart form data for use with `Content-Type: multipart/form-data` header.