### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  CHANGES
 =========
 
-5.4 (unreleased)
+6.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -31,7 +30,7 @@ TESTS_REQUIRE = [
     'zope.principalregistry >=4.0.0a1',
     'zope.securitypolicy >=4.0.0a1',
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 
@@ -76,9 +75,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',
         'Framework :: Zope :: 3',
     ],
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope', 'zope.app'],
     extras_require=dict(
         test=TESTS_REQUIRE,
         testlayer=['WebTest'],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def read(*rnames):
 
 setup(
     name='zope.app.wsgi',
-    version='5.4.dev0',
+    version='6.0.dev0',
     url='https://github.com/zopefoundation/zope.app.wsgi',
     project_urls={
         'Issue Tracker': ('https://github.com/zopefoundation/'

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/zope/app/__init__.py
+++ b/src/zope/app/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
